### PR TITLE
GCP 계정 전환 및 디스크 용량 조율

### DIFF
--- a/dev_always/main.tf
+++ b/dev_always/main.tf
@@ -300,7 +300,7 @@ resource "google_compute_disk" "ssmu_disk_test" {
   name  = var.gcp_disk_test_name
   type  = var.gcp_disk_type
   zone  = var.gcp_zone
-  size  = 30
+  size  = 80
 }
 
 # route53


### PR DESCRIPTION
fix: test disk 80GB, dev disk 150GB

